### PR TITLE
Updating code to work with latest Gutenberg API.

### DIFF
--- a/block.js
+++ b/block.js
@@ -7,7 +7,7 @@
 	var __                = wp.i18n.__; // The __() function for internationalization.
 	var createElement     = wp.element.createElement; // The wp.element.createElement() function to create elements.
 	var registerBlockType = wp.blocks.registerBlockType; // The registerBlockType() function to register blocks.
-	var Editable          = wp.blocks.Editable; // For creating editable elements.
+	var RichText          = wp.editor.RichText; // For creating editable elements.
 
 	/**
 	 * Register block
@@ -26,7 +26,7 @@
 			attributes: {
 				content: {
 					type: 'string',
-					default: 'Block content styled with CSS...',
+					default: 'Block content styled with CSS...'
 				},
 			},
 
@@ -39,7 +39,7 @@
 				}
 
 				return createElement(
-					Editable,
+					RichText,
 					{
 						tagName: 'p',
 						className: props.className,

--- a/block.js
+++ b/block.js
@@ -25,7 +25,9 @@
 			category: 'common', // Block category. Group blocks together based on common traits E.g. common, formatting, layout widgets, embed.
 			attributes: {
 				content: {
-					type: 'string',
+					type: 'array',
+					source: 'children',
+					selector: 'p',
 					default: 'Block content styled with CSS...'
 				},
 			},

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 .wp-block-mdlr-block-styles-example {
 	background-color: #333333;
-	color: #ffffff;
+	color: #ffffff !important;
 	padding: 1em 2em;
 }


### PR DESCRIPTION
Replacing the Editable object with the latest RichText API.
Adding an !important (¯\_(ツ)_/¯) to show the text, because another CSS rule overrides the color.